### PR TITLE
Fix toMod' to not truncate the result

### DIFF
--- a/src/Data/Modular.hs
+++ b/src/Data/Modular.hs
@@ -79,7 +79,7 @@ toMod i = Mod $ i `mod` unMod (_bound :: i `Mod` n)
 -- | Wraps an integral number to a mod, converting between integral
 -- types.
 toMod' :: forall n i j. (Integral i, Integral j, SingI n) => i -> j `Mod` n
-toMod' = toMod . fromIntegral
+toMod' i = toMod . fromIntegral $ i `mod` (fromInteger $ fromSing (sing :: Sing n))
 
 instance Show i => Show (i `Mod` n) where show (Mod i) = show i
 instance (Read i, Integral i, SingI n) => Read (i `Mod` n)


### PR DESCRIPTION
Change toMod' to first take the modulus and only then convert from one Integral to another.

Otherwise, if you have a large Integer  (say 2^100 :: Integer) and you convert it with the current toMod' into Int/10 then you get a wrong result. The number first gets truncated to fit into an Int, and then we take its remained mod 10.
