### PR TITLE
Modular inverse and new Integral instance

### DIFF
--- a/src/Data/Modular.hs
+++ b/src/Data/Modular.hs
@@ -37,7 +37,7 @@
 -- > *Data.Modular> (-10 :: ℤ/7) * (11 :: ℤ/7)
 -- > 2
 
-module Data.Modular (unMod, toMod, toMod', Mod, (/)(), ℤ) where
+module Data.Modular (unMod, toMod, toMod', Mod, inv, (/)(), ℤ) where
 
 import           Control.Arrow (first)
 
@@ -110,3 +110,15 @@ instance (Integral i, KnownNat n) => Real (i `Mod` n) where
 instance (Integral i, KnownNat n) => Integral (i `Mod` n) where
   toInteger (Mod i) = toInteger i
   Mod i₁ `quotRem` Mod i₂ = let (q, r) = i₁ `quotRem` i₂ in (toMod q, toMod r)
+
+-- | The modular inverse.
+-- Note that only numbers coprime to N have an inverse modulo N.
+inv :: forall n i. (KnownNat n, Integral i) => Mod i n -> Mod i n
+inv = toMod . snd . inv' (fromInteger (natVal (Proxy :: Proxy n))) . unMod
+  where
+    inv' _ 1 = (0, 1)
+    inv' n x = (r', q' - r' * q)
+      where
+        (q,  r)  = n `quotRem` x
+        (q', r') = inv' x r
+

--- a/src/Data/Modular.hs
+++ b/src/Data/Modular.hs
@@ -107,12 +107,15 @@ instance (Integral i, KnownNat n) => Bounded (i `Mod` n) where
 instance (Integral i, KnownNat n) => Real (i `Mod` n) where
   toRational (Mod i) = toInteger i % 1
 
+-- | Integer division uses modular inverse @'inv'@,
+-- so it is possible to divide only by numbers coprime to @n@
+-- and the remainder is always @0@.
 instance (Integral i, KnownNat n) => Integral (i `Mod` n) where
   toInteger (Mod i) = toInteger i
-  Mod i₁ `quotRem` Mod i₂ = let (q, r) = i₁ `quotRem` i₂ in (toMod q, toMod r)
+  i₁ `quotRem` i₂ = (i₁ * inv i₂, 0)
 
 -- | The modular inverse.
--- Note that only numbers coprime to N have an inverse modulo N.
+-- Note that only numbers coprime to @n@ have an inverse modulo @n@.
 inv :: forall n i. (KnownNat n, Integral i) => Mod i n -> Mod i n
 inv = toMod . snd . inv' (fromInteger (natVal (Proxy :: Proxy n))) . unMod
   where

--- a/src/Data/Modular.hs
+++ b/src/Data/Modular.hs
@@ -117,8 +117,14 @@ instance (Integral i, KnownNat n) => Integral (i `Mod` n) where
 -- | The modular inverse.
 -- Note that only numbers coprime to @n@ have an inverse modulo @n@.
 inv :: forall n i. (KnownNat n, Integral i) => Mod i n -> Mod i n
-inv = toMod . snd . inv' (fromInteger (natVal (Proxy :: Proxy n))) . unMod
+inv k = toMod . snd . inv' (fromInteger (natVal (Proxy :: Proxy n))) . unMod $ k
   where
+    -- these are only used for error message
+    modulus = show $ natVal (Proxy :: Proxy n)
+    divisor = show (toInteger k)
+
+    -- backwards Euclidean algorithm
+    inv' _ 0 = error ("division by " ++ divisor ++ " (mod " ++ modulus ++ "), non-coprime to modulus")
     inv' _ 1 = (0, 1)
     inv' n x = (r', q' - r' * q)
       where


### PR DESCRIPTION
In this implementation, `inv x` does not work when `x` is not coprime to `n` (with division by zero error).
If wanted this can be fixed this by either
- using `error` explicitly when numbers are not coprime;
- returning zero when numbers are not coprime;
- returning `Maybe (Mod i n)`.