### PR TITLE
SomeMod data type

### DIFF
--- a/src/Data/Modular.hs
+++ b/src/Data/Modular.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE GADTs               #-}
 
 -- |
 -- This module provides types for working with integers modulo some
@@ -37,7 +38,7 @@
 -- > *Data.Modular> (-10 :: ℤ/7) * (11 :: ℤ/7)
 -- > 2
 
-module Data.Modular (unMod, toMod, toMod', Mod, (/)(), ℤ, modVal) where
+module Data.Modular (unMod, toMod, toMod', Mod, (/)(), ℤ, modVal, SomeMod, someModVal) where
 
 import           Control.Arrow (first)
 
@@ -111,8 +112,22 @@ instance (Integral i, KnownNat n) => Integral (i `Mod` n) where
   toInteger (Mod i) = toInteger i
   Mod i₁ `quotRem` Mod i₂ = let (q, r) = i₁ `quotRem` i₂ in (toMod q, toMod r)
 
+-- | This type represents a modular number with unknown bound.
+data SomeMod i where
+  SomeMod :: forall i (n :: Nat). KnownNat n => Mod i n -> SomeMod i
+
+instance Show i => Show (SomeMod i) where
+  showsPrec p (SomeMod x) = showsPrec p x
+
 -- | Convert an integral number @i@ into a @'Mod'@ value given
 -- modular bound @n@ at type level.
 modVal :: forall i proxy n. (Integral i, KnownNat n) => i -> proxy n -> Mod i n
 modVal i _ = toMod i
+
+-- | Convert an integral number @i@ into an unknown @'Mod'@ value.
+someModVal :: Integral i => i -> Integer -> Maybe (SomeMod i)
+someModVal i n =
+  case someNatVal n of
+    Nothing -> Nothing
+    Just (SomeNat proxy) -> Just (SomeMod (modVal i proxy))
 

--- a/src/Data/Modular.hs
+++ b/src/Data/Modular.hs
@@ -37,7 +37,7 @@
 -- > *Data.Modular> (-10 :: ℤ/7) * (11 :: ℤ/7)
 -- > 2
 
-module Data.Modular (unMod, toMod, toMod', Mod, (/)(), ℤ) where
+module Data.Modular (unMod, toMod, toMod', Mod, (/)(), ℤ, modVal) where
 
 import           Control.Arrow (first)
 
@@ -110,3 +110,9 @@ instance (Integral i, KnownNat n) => Real (i `Mod` n) where
 instance (Integral i, KnownNat n) => Integral (i `Mod` n) where
   toInteger (Mod i) = toInteger i
   Mod i₁ `quotRem` Mod i₂ = let (q, r) = i₁ `quotRem` i₂ in (toMod q, toMod r)
+
+-- | Convert an integral number @i@ into a @'Mod'@ value given
+-- modular bound @n@ at type level.
+modVal :: forall i proxy n. (Integral i, KnownNat n) => i -> proxy n -> Mod i n
+modVal i _ = toMod i
+


### PR DESCRIPTION
These extra data type and functions are implemented in a similar manner to ones in [`GHC.TypeLits`](http://hackage.haskell.org/package/base/docs/GHC-TypeLits.html).