### PR TITLE
README and CHANGELOG as extra-source-files

### DIFF
--- a/modular-arithmetic.cabal
+++ b/modular-arithmetic.cabal
@@ -14,6 +14,8 @@ author:              Tikhon Jelvis <tikhon@jelv.is>
 maintainer:          tikhon@jelv.is
 category:            Math
 build-type:          Simple
+extra-source-files:  README.md
+                   , CHANGELOG.md
 cabal-version:       >=1.8
 
 source-repository head


### PR DESCRIPTION
This way they will be included when you do `cabal sdist`.