### PR TITLE
Removed the dependency on the Glob package.

### DIFF
--- a/modular-arithmetic.cabal
+++ b/modular-arithmetic.cabal
@@ -26,12 +26,11 @@ library
   hs-source-dirs:      src
   ghc-options:         -Wall
   exposed-modules:     Data.Modular
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base
 
 test-suite examples
   hs-source-dirs:      test-suite
   main-is:             DocTest.hs
   type:                exitcode-stdio-1.0
-  build-depends:       base >= 4.7 && < 5
-                     , Glob >= 0.7 && < 0.8
-                     , doctest >= 0.9 && < 0.15
+  build-depends:       base
+                     , doctest >= 0.9

--- a/test-suite/DocTest.hs
+++ b/test-suite/DocTest.hs
@@ -1,7 +1,6 @@
 module Main (main) where
 
-import           System.FilePath.Glob (glob)
 import           Test.DocTest         (doctest)
 
 main :: IO ()
-main = glob "src/**/*.hs" >>= doctest
+main = doctest ["src/Data/Modular.hs"]


### PR DESCRIPTION
The Glob package was providing a minor utility function for automatically running doctest over all the *.hs files in the project, but was also consistently causing compilation issues. The minor convenience of globbing all the *.hs files is not worth the compilation issues, so I got rid of the dependency.