### PR TITLE
Disable Travis for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ cabal.sandbox.config
 dist
 dist-newstyle
 cabal-dev
+cabal.project.local
 
 # Emacs
 *~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: haskell
-ghc: 8.8.3
-cabal: 3.2
-install: cabal install --lib --only-dependencies --write-ghc-environment-files=always
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
-language: nix
-nix: 2.3.7
+language: haskell
+ghc: 8.8.3
+cabal: 3.2
+install: cabal install --lib --only-dependencies --write-ghc-environment-files=always
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 language: haskell
 ghc: 8.8.3
+cabal: 3.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-language: haskell
-ghc: 8.8.3
-cabal: 3.2
-install: cabal install --lib --only-dependencies
+language: nix
+nix: 2.3.7
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: haskell
 ghc: 8.8.3
 cabal: 3.2
-install: cabal install --only-dependencies
+install: cabal install --lib --only-dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: haskell
 ghc: 8.8.3
 cabal: 3.2
+install: cabal install --only-dependencies

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Modular Arithmetic
 
 [![Hackage package](http://img.shields.io/hackage/v/modular-arithmetic.svg)](http://hackage.haskell.org/package/modular-arithmetic)
-[![Build Status](https://travis-ci.org/TikhonJelvis/modular-arithmetic.svg?branch=master)](https://travis-ci.org/TikhonJelvis/modular-arithmetic)
+
 
 This package provides a type for integers modulo some constant, usually written as ℤ/n. 
 

--- a/modular-arithmetic.cabal
+++ b/modular-arithmetic.cabal
@@ -36,5 +36,6 @@ test-suite examples
   default-language:    Haskell2010
   type:                exitcode-stdio-1.0
   build-depends:       base >4.9 && <5
+                     , modular-arithmetic
                      , doctest >= 0.9
                      , typelits-witnesses <0.5

--- a/modular-arithmetic.cabal
+++ b/modular-arithmetic.cabal
@@ -31,11 +31,10 @@ library
                      , typelits-witnesses <0.5
 
 test-suite examples
-  hs-source-dirs:      test-suite
+  hs-source-dirs:      test-suite, src
   main-is:             DocTest.hs
   default-language:    Haskell2010
   type:                exitcode-stdio-1.0
   build-depends:       base >4.9 && <5
-                     , modular-arithmetic
                      , doctest >= 0.9
                      , typelits-witnesses <0.5


### PR DESCRIPTION
Getting doctests to work reliably now that I have an external dependency has been way too much of a headache to be worth it. I'm just going to ignore them for now. Hoping that better doctest integration comes along to either haskell.nix or cabal new-style builds so that I don't have to deal with this any more.