### PR TITLE
Fix for 9.2+

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,16 +41,18 @@
       rec {
         # TODO: cleaner way to manage multiple GHC versions...
         packages = {
+          modular-arithmetic_924 = package "ghc924";
           modular-arithmetic_902 = package "ghc902";
           modular-arithmetic_8107 = package "ghc8107";
         };
 
         devShells = {
+          modular-arithmetic_924 = shellFor "ghc924";
           modular-arithmetic_902 = shellFor "ghc902";
           modular-arithmetic_8107 = shellFor "ghc8107";
         };
 
-        defaultPackage = packages.modular-arithmetic_902;
-        devShell = devShells.modular-arithmetic_902;
+        defaultPackage = packages.modular-arithmetic_924;
+        devShell = devShells.modular-arithmetic_924;
       });
 }

--- a/modular-arithmetic.cabal
+++ b/modular-arithmetic.cabal
@@ -28,7 +28,8 @@ library
   default-language:    Haskell2010
   exposed-modules:     Data.Modular
   build-depends:       base >4.9 && <5
-                     , typelits-witnesses <0.5
+  if impl(ghc < 9.2.1)
+    build-depends:     typelits-witnesses <0.5
 
 test-suite examples
   hs-source-dirs:      test-suite, src
@@ -37,4 +38,5 @@ test-suite examples
   type:                exitcode-stdio-1.0
   build-depends:       base >4.9 && <5
                      , doctest >= 0.9
-                     , typelits-witnesses <0.5
+  if impl(ghc < 9.2.1)
+    build-depends:     typelits-witnesses <0.5


### PR DESCRIPTION
I've verified that this change builds using GHC 8.10.7, 9.0.2, and 9.2.4.

The doctests only pass for me on 9.2.4, but that might be due to how I'm using Nix. It appears that _doctest_ cannot see _typelits-witnesses_.

```
cabal repl test:examples

λ :show packages
active package flags:
  -package-id typelits-witnesses-0.4.0.0-5eCXrhtGP6h57ytsIr2YQw
  -package-id doctest-0.20.0-LibhKUW41H15QzzuYGnY3a
  -package-id base-4.14.3.0

λ :l src/Data/Modular.hs
[1 of 1] Compiling Data.Modular     ( src/Data/Modular.hs, interpreted )
Ok, one module loaded.

λ import Test.DocTest (doctest)
λ doctest ["src/Data/Modular.hs"]

src/Data/Modular.hs:44:1: error:
    Could not find module ‘GHC.TypeLits.Compare’
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
```