### PR TITLE
Fix build for GHC 9.4+, bump to 2.0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2.0.0.3
+---
+* Fixed build for GHC 9.4+
+
 2.0.0.0
 ---
 * replaced `Integral` instance with `Fractional` instance (see #8 and #14)

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675815091,
-        "narHash": "sha256-a3R8wZLiGB4g2pb2cznEhRqLloViqh6aRMMg8Rkwfjc=",
+        "lastModified": 1686263882,
+        "narHash": "sha256-p5shz5DDVaqISuCH5L4roYP0uz+RNbnTgsUWsvxclAc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5ce8986dff8e06ace05a0158fe617707228ac25",
+        "rev": "a164b42bb3ba65f43253a06193fc22d301c6d012",
         "type": "github"
       },
       "original": {
@@ -34,6 +37,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -41,20 +41,20 @@
       rec {
         # TODO: cleaner way to manage multiple GHC versions...
         packages = {
+          modular-arithmetic_961 = package "ghc961";
           modular-arithmetic_944 = package "ghc944";
           modular-arithmetic_924 = package "ghc924";
           modular-arithmetic_902 = package "ghc902";
-          modular-arithmetic_8107 = package "ghc8107";
         };
 
         devShells = {
+          modular-arithmetic_961 = shellFor "ghc961";
           modular-arithmetic_944 = shellFor "ghc944";
           modular-arithmetic_924 = shellFor "ghc924";
           modular-arithmetic_902 = shellFor "ghc902";
-          modular-arithmetic_8107 = shellFor "ghc8107";
         };
 
-        defaultPackage = packages.modular-arithmetic_924;
-        devShell = devShells.modular-arithmetic_924;
+        defaultPackage = packages.modular-arithmetic_961;
+        devShell = devShells.modular-arithmetic_961;
       });
 }

--- a/modular-arithmetic.cabal
+++ b/modular-arithmetic.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                modular-arithmetic
-version:             2.0.0.2
+version:             2.0.0.3
 synopsis:            A type for integers modulo some constant.
 
 description:         A convenient type for working with integers modulo some constant. It saves you from manually wrapping numeric operations all over the place and prevents a range of simple mistakes. @Integer `Mod` 7@ is the type of integers (mod 7) backed by @Integer@.
@@ -15,7 +15,7 @@ author:              Tikhon Jelvis <tikhon@jelv.is>
 maintainer:          Tikhon Jelvis <tikhon@jelv.is>
 category:            Math
 build-type:          Simple
-extra-source-files:  README.md
+extra-doc-files:  README.md
                    , CHANGELOG.md
 
 source-repository head
@@ -37,6 +37,6 @@ test-suite examples
   default-language:    Haskell2010
   type:                exitcode-stdio-1.0
   build-depends:       base >4.9 && <5
-                     , doctest >= 0.9
+                     , doctest >= 0.9 && <0.22
   if impl(ghc < 9.2.1)
     build-depends:     typelits-witnesses <0.5

--- a/src/Data/Modular.hs
+++ b/src/Data/Modular.hs
@@ -1,14 +1,16 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE ConstraintKinds     #-}
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE ExplicitNamespaces  #-}
-{-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeOperators       #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE AllowAmbiguousTypes  #-}
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE ConstraintKinds      #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE ExplicitNamespaces   #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 
 -- |
 -- Types for working with integers modulo some constant.
@@ -25,23 +27,23 @@ module Data.Modular (
   modVal, SomeMod, someModVal
 ) where
 
-import           Control.Arrow (first)
+import           Control.Arrow          (first)
 
-import           Data.Proxy    (Proxy (..))
-import           Data.Ratio    ((%), denominator, numerator)
+import           Data.Proxy             (Proxy (..))
+import           Data.Ratio             (denominator, numerator, (%))
 
-import           Text.Printf   (printf)
+import           Text.Printf            (printf)
 
 #if MIN_VERSION_base(4,11,0)
-import           GHC.TypeLits hiding (Mod)
+import           GHC.TypeLits           hiding (Mod)
 #else
 import           GHC.TypeLits
 #endif
 
 #if !MIN_VERSION_base(4,16,0)
-import           Data.Type.Equality     ((:~:)(..))
+import           Data.Type.Equality     ((:~:) (..))
 
-import           GHC.TypeLits.Compare   ((%<=?), (:<=?)(LE, NLE))
+import           GHC.TypeLits.Compare   ((%<=?), (:<=?) (LE, NLE))
 import           GHC.TypeLits.Witnesses (SNat (SNat))
 #endif
 


### PR DESCRIPTION
Fix the error from #24, clean `cabal check` warnings, bump to 2.0.0.3